### PR TITLE
Created buildout_versions parser, fixes issue #2

### DIFF
--- a/folivora/tests.py
+++ b/folivora/tests.py
@@ -694,3 +694,66 @@ class TestPipRequirementsParsers(TestCase):
             ContentFile(EMPTY_REQUIREMENTS))
         self.assertEqual(packages, {})
         self.assertEqual(missing, [])
+
+
+class TestBuildoutVersionsParser(TestCase):
+    SIMPLE = '''[versions]
+Django = 1.4.1
+'''
+
+    RENAMED = '''[buildout]
+versions = pinnedversions
+
+[pinnedversions]
+Django = 1.4.1
+'''
+
+    MISSING = '''[versions]
+Sphinx==1.10
+Django =
+'''
+
+    COMMENTED = '''[versions]
+# Sphinx = 1.10
+Django = 1.4.1 ; 1.4.0
+rem Sphinx = 1.10
+'''
+
+    BROKEN = '''
+Sphinx = 1.10
+[versions
+foo = 1.0
+'''
+
+    def setUp(self):
+        self.parse = get_parser('buildout_versions').parse
+
+    def test_simple(self):
+        packages, missing = self.parse(ContentFile(self.SIMPLE))
+        self.assertEqual({'Django': '1.4.1'}, packages)
+        self.assertEqual([], missing)
+
+    def test_renamed(self):
+        packages, missing = self.parse(ContentFile(self.RENAMED))
+        self.assertEqual({'Django': '1.4.1'}, packages)
+        self.assertEqual([], missing)
+
+    def test_missing(self):
+        packages, missing = self.parse(ContentFile(self.MISSING))
+        self.assertEqual({}, packages)
+        self.assertItemsEqual(['Django', 'Sphinx'], missing)
+
+    def test_commented(self):
+        packages, missing = self.parse(ContentFile(self.COMMENTED))
+        self.assertEqual({'Django': '1.4.1'}, packages)
+        self.assertEqual([], missing)
+
+    def test_broken(self):
+        packages, missing = self.parse(ContentFile(self.BROKEN))
+        self.assertEqual({}, packages)
+        self.assertEqual([], missing)
+
+    def test_parse_empty(self):
+        packages, missing = self.parse(ContentFile(EMPTY_REQUIREMENTS))
+        self.assertEqual({}, packages)
+        self.assertEqual([], missing)

--- a/folivora/utils/parsers.py
+++ b/folivora/utils/parsers.py
@@ -1,12 +1,15 @@
 #-*- coding: utf-8 -*-
 import pkg_resources
-from collections import namedtuple
+import re
 from django.utils.translation import ugettext_lazy
 
 
 class BaseParser(object):
     name = None
     title = None
+
+    def parse(self, lines):
+        raise NotImplementedError
 
 
 def get_parser(name):
@@ -45,4 +48,81 @@ class PipRequirementsParser(BaseParser):
         return packages, missing
 
 
-PARSERS = [PipRequirementsParser]
+class BuildoutVersionsParser(BaseParser):
+    name = 'buildout_versions'
+    title = ugettext_lazy('Buildout Versions')
+
+    # Ref: https://github.com/buildout/buildout/blob/master/src/zc/buildout/configparser.py
+    RE_SECTION = re.compile(
+        r'\['                                 # [
+        r'(?P<header>[^]]+)'                  # very permissive!
+        r'\]'                                 # ]
+    )
+    RE_OPTION = re.compile(
+        r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
+        r'\s*(?P<vi>[:=])\s*'                 # any number of space/tab,
+        # followed by separator
+        # (either : or =), followed
+        # by any # space/tab
+        r'(?P<value>.*)$'                     # everything up to eol
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(BuildoutVersionsParser, self).__init__(*args, **kwargs)
+        self._sections = {}
+        self._cur_sect = None
+
+    def _is_ignorable(self, line):
+        # whitespace & comments are ignorable
+        return ((line.strip() == '' or line[0] in '#;') or
+                (line.split(None, 1)[0].lower() == 'rem' and line[0] in "rR"))
+
+    def _handle_line(self, line):
+        if self._is_ignorable(line):
+            return
+        # is it a section header?
+        match = self.RE_SECTION.match(line)
+        if match:
+            header = match.group('header')
+            if header in self._sections:
+                self._cur_sect = self._sections[header]
+            else:
+                self._cur_sect = {}
+                self._sections[header] = self._cur_sect
+        # is it an option line?
+        if self._cur_sect is not None:
+            match = self.RE_OPTION.match(line)
+            if match:
+                option, vi, value = match.group('option', 'vi', 'value')
+                if value is not None:
+                    if ';' in value:
+                        # ';' is a comment delimiter only if it follows
+                        # a spacing character
+                        pos = value.find(';')
+                        if pos != -1 and value[pos-1].isspace():
+                            value = value[:pos]
+                    value = value.strip()
+                # allow empty values
+                if value == '""':
+                    value = ''
+                option = option.rstrip()
+                self._cur_sect[option] = value
+
+    def parse(self, lines):
+        for line in lines:
+            self._handle_line(line)
+        self._cur_sect = None
+        buildout = self._sections.get('buildout', {})
+        versions_section = buildout.get('versions', 'versions')
+        versions = self._sections.get(versions_section, {})
+        packages = {}
+        missing = []
+        for package, version in versions.items():
+            if version and version[0] != '=':
+                packages[package] = version
+            else:
+                missing.append(package)
+        return packages, missing
+
+
+PARSERS = [PipRequirementsParser, BuildoutVersionsParser]


### PR DESCRIPTION
Added a buildout specific parser. It's compatible with the output generated by either:
- [buildout.dumppickedversions](http://pypi.python.org/pypi/buildout.dumppickedversions)
- [buildout-versions](http://pypi.python.org/pypi/buildout-versions)

and with a manually maintained [versions] section.
